### PR TITLE
docs: document post frontmatter and the language locale filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,39 @@ You will be prompted to select component type (atoms, molecules, organisms, temp
 ```bash
 pnpm new-post
 ```
+
+## Post frontmatter
+
+Posts live in `content/posts/*.mdx` and are parsed by ContentLayer (see `contentlayer.config.js`).
+
+| Field           | Required | Default | Notes                                              |
+| --------------- | -------- | ------- | -------------------------------------------------- |
+| `title`         | ✅       | –       |                                                     |
+| `slug`          | ✅       | –       | The post is served at `/posts/<slug>`               |
+| `date`          | ✅       | –       |                                                     |
+| `description`   | ✅       | –       |                                                     |
+| `socialImage`   | ✅       | –       |                                                     |
+| `language`      | –        | `zh-TW` | One of `en` / `zh-TW`, see below                     |
+| `isDraft`       | –        | `false` |                                                     |
+| `redirect_from` | –        | –       | List of old paths that should redirect to this post |
+
+### About `language`
+
+This site is bilingual (`en` and `zh-TW`, see `next-i18next.config.js`), and the post lists —
+`/posts`, `/posts/page/[page]`, the homepage and the command palette — only show posts whose
+`language` matches the current locale. (The RSS feed is not filtered and includes every post.)
+
+Because `language` defaults to `zh-TW`, a post **without** an explicit `language` field will not
+appear in the English (default locale) post list at `/posts`, even though its own page at
+`/posts/<slug>` is still generated and reachable. If a post renders but is missing from the list,
+add the matching language to its frontmatter:
+
+```yaml
+---
+title: 'My post'
+slug: 'my-post'
+language: en
+---
+```
+
+Posts created with `pnpm new-post` already include this field.


### PR DESCRIPTION
Closes #25.

## Context

A user reported that a post they added rendered fine at `/posts/<slug>` but never showed up in the post list at `/posts`.

The cause is a documentation gap rather than a code bug:

- `contentlayer.config.js` declares `language` as an enum of `en` / `zh-TW` with `default: 'zh-TW'`.
- `allPostsOfLocaleNewToOld()` in `src/lib/contentLayerAdapter.js` filters by `post.language === locale`, and `next-i18next.config.js` sets `defaultLocale: 'en'`.
- `src/pages/posts/[...slug].tsx` generates a page for every post in **every** locale, ignoring `language`.

So a post written without an explicit `language` silently becomes a zh-TW post: its own page is reachable, but it is absent from the English lists. Nothing documented that.

## Changes

Adds a "Post frontmatter" section to the README:

- A table of the frontmatter fields with required/default columns.
- An "About `language`" subsection explaining which surfaces are locale-filtered (`/posts`, `/posts/page/[page]`, the homepage and the command palette — the RSS feed is not), why a missing `language` hides a post from `/posts`, and how to fix it.
- A note that `pnpm new-post` already scaffolds the field.

Docs only — no behavior change.

## Not changed

41 of the 116 posts in `content/posts` rely on the `zh-TW` default, so flipping the contentlayer default to match `defaultLocale: 'en'` would silently move all of them into the English listing. Left as-is deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Av5ew9VPDSQgqBP5zKqGVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Av5ew9VPDSQgqBP5zKqGVm)_