### PR TITLE
Modernization 5/6: AI-readable endpoints — llms.txt, raw markdown, JSON-LD

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -52,12 +52,26 @@ test.describe('meta routes', () => {
     '/feed.json',
     '/sitemap.xml',
     '/robots.txt',
+    '/llms.txt',
+    '/llms-full.txt',
   ]) {
     test(`serves ${path}`, async ({ request }) => {
       const response = await request.get(path);
       expect(response.status()).toBe(200);
     });
   }
+
+  test('serves raw markdown for posts', async ({ request }) => {
+    const response = await request.get('/zh-TW/posts/less-but-better.md');
+    expect(response.status()).toBe(200);
+    expect(response.headers()['content-type']).toContain('text/markdown');
+    expect(await response.text()).toContain('少，但是更好');
+  });
+
+  test('404s raw markdown for unknown posts', async ({ request }) => {
+    const response = await request.get('/posts/not-a-real-post.md');
+    expect(response.status()).toBe(404);
+  });
 });
 
 test.describe('not found', () => {

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -128,6 +128,38 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
     path: post.path,
   }));
 
+  const identityData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': `${siteMetadata.siteUrl}/#website`,
+        url: siteMetadata.siteUrl,
+        name: siteMetadata.title,
+        description: siteMetadata.description,
+        inLanguage: ['en', 'zh-TW'],
+        publisher: { '@id': `${siteMetadata.siteUrl}/#person` },
+      },
+      {
+        '@type': 'Person',
+        '@id': `${siteMetadata.siteUrl}/#person`,
+        name: siteMetadata.author,
+        url: siteMetadata.siteUrl,
+        image: siteMetadata.siteUrl + siteMetadata.siteLogo,
+        email: siteMetadata.email,
+        sameAs: [
+          siteMetadata.github,
+          siteMetadata.linkedin,
+          siteMetadata.twitter,
+          siteMetadata.facebook,
+          siteMetadata.instagram,
+          siteMetadata.threads,
+          siteMetadata.bluesky,
+        ],
+      },
+    ],
+  };
+
   return (
     <html
       lang={locale}
@@ -135,6 +167,11 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
       className={`${inter.variable} ${notoSansTC.variable}`}
     >
       <body className="overflow-x-hidden bg-white text-gray-950 antialiased transition-colors dark:bg-gray-950 dark:text-white">
+        <script
+          type="application/ld+json"
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD built from trusted site metadata
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(identityData) }}
+        />
         <NextIntlClientProvider messages={messages}>
           <ThemeProvider attribute="class" defaultTheme={siteMetadata.theme}>
             <CommandPalette posts={commandPalettePosts}>

--- a/src/app/[locale]/posts/[...slug]/page.tsx
+++ b/src/app/[locale]/posts/[...slug]/page.tsx
@@ -1,7 +1,7 @@
 import { MDXContent } from '@content-collections/mdx/react';
 import type { Metadata } from 'next';
 import { notFound, redirect } from 'next/navigation';
-import { setRequestLocale } from 'next-intl/server';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
 
 import PageTitle from '@/components/PageTitle';
 import siteMetadata from '@/data/siteMetadata';
@@ -65,6 +65,13 @@ export async function generateMetadata({
 
   return {
     ...metadata,
+    alternates: {
+      ...metadata.alternates,
+      types: {
+        // Raw markdown variant for agents and LLMs (see /llms.txt).
+        'text/markdown': `${post.path}.md`,
+      },
+    },
     openGraph: {
       ...metadata.openGraph,
       type: 'article',
@@ -106,6 +113,32 @@ export default async function PostPage({ params }: PageProps) {
     );
   }
 
+  const t = await getTranslations({ locale, namespace: 'common' });
+  const breadcrumbData = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        position: 1,
+        name: t('home'),
+        item: localizedUrl(locale, '/'),
+      },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: t('all-posts'),
+        item: localizedUrl(locale, '/posts'),
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: post.title,
+        item: localizedUrl(locale, post.path),
+      },
+    ],
+  };
+
   const structuredData = {
     '@context': 'https://schema.org',
     '@type': 'Article',
@@ -140,6 +173,11 @@ export default async function PostPage({ params }: PageProps) {
         type="application/ld+json"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD built from trusted frontmatter
         dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: static JSON-LD built from trusted frontmatter
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbData) }}
       />
       <PostLayout
         post={{

--- a/src/app/api/markdown/[slug]/route.ts
+++ b/src/app/api/markdown/[slug]/route.ts
@@ -1,0 +1,39 @@
+import type { NextRequest } from 'next/server';
+
+import { allPostsNewToOld } from '@/lib/content';
+import { localizedUrl } from '@/lib/seo';
+
+// Serves the raw markdown of a post. Reached via /posts/<slug>.md
+// (and /zh-TW/posts/<slug>.md), rewritten here by src/proxy.ts so agents
+// and LLMs can skip HTML parsing entirely.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ slug: string }> }
+) {
+  const { slug } = await params;
+  const locale = request.nextUrl.searchParams.get('locale') ?? 'en';
+
+  const candidates = allPostsNewToOld.filter((post) => post.slug === slug);
+  if (candidates.length === 0) {
+    return new Response('Not found', { status: 404 });
+  }
+  const post =
+    candidates.find((candidate) => candidate.language === locale) ??
+    candidates[0];
+
+  const body = `# ${post.title}
+
+- Canonical: ${localizedUrl(post.language, post.path)}
+- Date: ${post.date}
+- Language: ${post.language}
+${post.description ? `- Description: ${post.description}\n` : ''}
+${post.raw.trim()}
+`;
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+    },
+  });
+}

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,0 +1,28 @@
+import siteMetadata from '@/data/siteMetadata';
+import { allPostsNewToOld } from '@/lib/content';
+import { localizedUrl } from '@/lib/seo';
+
+export const dynamic = 'force-static';
+
+// https://llmstxt.org — full-content companion to /llms.txt.
+export function GET() {
+  const sections = allPostsNewToOld.map((post) => {
+    const url = localizedUrl(post.language, post.path);
+    return `# ${post.title}
+
+- URL: ${url}
+- Date: ${post.date}
+- Language: ${post.language}
+${post.description ? `- Description: ${post.description}\n` : ''}
+${post.raw.trim()}`;
+  });
+
+  const body = `<!-- ${siteMetadata.title} — full content of all posts, newest first -->
+
+${sections.join('\n\n---\n\n')}
+`;
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,46 @@
+import siteMetadata from '@/data/siteMetadata';
+import { allPostsOfLocaleNewToOld } from '@/lib/content';
+import { localizedUrl } from '@/lib/seo';
+
+export const dynamic = 'force-static';
+
+// https://llmstxt.org — a map of the site for LLMs and agents.
+export function GET() {
+  const enPosts = allPostsOfLocaleNewToOld('en');
+  const zhPosts = allPostsOfLocaleNewToOld('zh-TW');
+
+  const postLine = (locale: string) => (post: (typeof enPosts)[number]) => {
+    const url = localizedUrl(locale, post.path);
+    const description = post.description ? `: ${post.description}` : '';
+    return `- [${post.title}](${url}.md)${description}`;
+  };
+
+  const body = `# ${siteMetadata.title}
+
+> ${siteMetadata.description}
+
+Personal blog of ${siteMetadata.author}, a fullstack developer from Taiwan living in Canada. Posts cover software engineering, web development, maker projects, and productivity, written in English and Traditional Chinese. Every post is also available as raw markdown by appending \`.md\` to its URL.
+
+## Posts (English)
+
+${enPosts.map(postLine('en')).join('\n')}
+
+## Posts (繁體中文)
+
+${zhPosts.map(postLine('zh-TW')).join('\n')}
+
+## Pages
+
+- [About](${localizedUrl('en', '/about')}): About ${siteMetadata.author}
+- [Projects](${localizedUrl('en', '/projects')}): Side projects and works
+
+## Optional
+
+- [Full content dump](${siteMetadata.siteUrl}/llms-full.txt): every post in one markdown file
+- [RSS feed](${siteMetadata.siteUrl}/feed.xml)
+`;
+
+  return new Response(body, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,13 +1,35 @@
+import { type NextRequest, NextResponse } from 'next/server';
 import createMiddleware from 'next-intl/middleware';
 
 import { routing } from './i18n/routing';
 
 // Locale negotiation (Accept-Language + NEXT_LOCALE cookie), matching the
 // behavior of the old Pages Router built-in i18n.
-export default createMiddleware(routing);
+const handleI18nRouting = createMiddleware(routing);
+
+const POST_MARKDOWN_PATTERN = /^\/(?:zh-TW\/)?posts\/([^/]+)\.md$/;
+
+export default function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // /posts/<slug>.md → raw markdown for agents/LLMs (see /llms.txt).
+  const markdownMatch = pathname.match(POST_MARKDOWN_PATTERN);
+  if (markdownMatch) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/api/markdown/${markdownMatch[1]}`;
+    url.searchParams.set(
+      'locale',
+      pathname.startsWith('/zh-TW/') ? 'zh-TW' : 'en'
+    );
+    return NextResponse.rewrite(url);
+  }
+
+  return handleI18nRouting(request);
+}
 
 export const config = {
-  // Skip Next.js internals, API routes, and all static files.
+  // Skip Next.js internals, API routes, and all static files (but let
+  // .md post URLs through — they are rewritten above).
   matcher:
     '/((?!api|_next|_vercel|.*\\.(?:ico|png|jpg|jpeg|gif|svg|webp|avif|txt|xml|json|pdf|webmanifest|js|css|map)).*)',
 };


### PR DESCRIPTION
Stacked on #31. Makes the blog a first-class citizen for LLMs, agents, and answer engines — **static routes only, no AI-powered runtime features** (per review: no RAG chat, no embeddings, no MCP server).

## New endpoints

- **`/llms.txt`** ([llmstxt.org](https://llmstxt.org)) — site summary plus an index of every post in both languages, each linked in its raw-markdown form
- **`/llms-full.txt`** — the full-content companion: all 116 posts in one statically generated markdown document (~670 KB)
- **`/posts/<slug>.md`** (and `/zh-TW/posts/<slug>.md`) — raw markdown per post with a small metadata header (canonical URL, date, language). Implemented as a proxy rewrite to a route handler since dynamic segments can't carry extensions. Post pages advertise it via `<link rel="alternate" type="text/markdown">`.

## Structured data for answer engines (AEO)

- `WebSite` + `Person` graph (with `sameAs` for all social profiles) on every page
- `BreadcrumbList` on post pages
- These join the existing `Article` schema from the platform phase

## Verification

Build green (180 static routes now) · biome clean · e2e suite extended to cover all new endpoints — **15/15 passing**, including content-type and 404 behavior of the markdown routes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpUq2fgkf8uUNXZcXPZtuj)_