### PR TITLE
Modernization 8/8: AI-ready repo — CLAUDE.md + write-post / translate-post skills

### DIFF
--- a/.claude/skills/translate-post/SKILL.md
+++ b/.claude/skills/translate-post/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: translate-post
+description: Translate an existing easonchang.com blog post between Traditional Chinese and English, creating the paired-language MDX file. Use when asked to translate a post, add an English/Chinese version of a post, or fill in a missing language version.
+---
+
+# Translating a post to its paired language
+
+Posts pair across languages by sharing a `slug`. This skill creates the missing half of a pair.
+
+## Process
+
+1. Read the source MDX in `content/posts/` fully — frontmatter and body.
+2. Create the target file next to it:
+   - zh-TW file `YYYY-MM-DD-<slug>.mdx` ↔ en file `YYYY-MM-DD-<slug>-en.mdx`
+3. Copy the frontmatter, then:
+   - Translate `title` and `description` naturally (see below)
+   - Set `language` to the target locale
+   - Keep `slug`, `date`, `socialImage`, `tags`, `category` identical
+   - Do NOT copy `redirect_from` unless those legacy URLs genuinely apply to the target locale
+4. Translate the body **section by section, preserving structure exactly**: same headings hierarchy, same lists, same images, same links, same code blocks (code and code-fence titles stay untouched).
+
+## Translation style — read `.claude/skills/write-post/SKILL.md` first
+
+This is a rewrite in Eason's voice, not a literal translation:
+
+- Reorder sentences where the target language flows better; keep meaning identical
+- zh-TW: 「」quotes, full-width punctuation, spaces between CJK and Latin, keep tech terms in English, reader is 你
+- en: simple friendly sentences; drop Chinese-only asides (e.g. 「（Maker）」 gloss) when redundant
+- Emoji and tone markers carry over where natural, not mechanically
+- Internal links (`/posts/...`) stay as-is — the site localizes them automatically. External links stay identical unless a locale-specific account exists (e.g. X: `easondev` for en, `easondev_tw` for zh)
+
+## Before finishing
+
+1. `pnpm build` must pass
+2. Verify the pair: both files share the `slug`, each declares its own `language`, and neither file was renamed

--- a/.claude/skills/write-post/SKILL.md
+++ b/.claude/skills/write-post/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: write-post
+description: Write a new blog post for easonchang.com in Eason's voice and style, in Traditional Chinese, English, or both. Use whenever asked to write, draft, or scaffold a blog post, article, or project introduction for this site.
+---
+
+# Writing a blog post as Eason
+
+You are writing as **Eason Chang** — a Taiwanese fullstack developer living in Calgary, writing for developers and makers. Posts are personal, practical, and friendly. Never write like a press release or a textbook.
+
+## Voice and style (both languages)
+
+- **First person, conversational.** Write "I/we" ("我/我們"). Share the personal motivation behind everything: why I built this, what problem I hit, what I learned.
+- **Short paragraphs.** 1–3 sentences each. One idea per paragraph.
+- **Bold key terms** on first mention: product names, tech names, important concepts.
+- **Link generously inline**: every tool, product, person, or prior post gets a link the first time it appears.
+- **Bulleted lists with bold labels** for features/reasons: `- **Label:** description`.
+- Tech stacks are bulleted as `- [Name](url)：why I like it` (one line of justification each).
+- Emoji are used sparingly for warmth (👋 🇹🇼 🇨🇦 😆 ～), mostly in intros/outros — never more than a few per post.
+- End posts with an invitation: try it, join the waitlist, tell me what you think, find me on X / email me.
+- Honesty over hype: state real status (beta, waitlist, archived) plainly. No invented metrics or features — only what is true.
+
+## Post structures that Eason uses
+
+**Project posts** (introducing something built):
+1. Cover image
+2. `## 簡介` / `## Introduction` — what it is, one or two sentences; credit collaborators (e.g. Carol) with links
+3. `## Demo & 程式碼` / `## Demo & Source Code` — bulleted **Demo:** / **Source Code:** links (when public)
+4. `## 為什麼我們要開發這個專案` / `## Why we created this project` — the personal story behind it
+5. `## 主打功能` / `## Key Features` — bold-label bullets
+6. `## 技術架構` / `## Technologies` — tech stack bullets (when relevant)
+7. Closing: current status + call to action
+
+**Tutorial/series posts**:
+1. One-sentence intro of what this article covers
+2. Optional blockquote linking to the full code diff (GitHub compare URL)
+3. `---` divider
+4. `##` sections walking through the steps, with code blocks
+5. Result/summary section, link to next article in the series
+
+## Language conventions
+
+**Traditional Chinese (zh-TW)** — the default language:
+- Use 「」 for quoted names/terms:「智慧釀藏酒大師 Winster」
+- Full-width punctuation：，。：！？、
+- Keep technical terms in English (Server Side Rendering, Tech Stack, Demo, Beta); add Chinese in parens only when the term is uncommon: 時間箱（Time Boxing）
+- Put a space between CJK and Latin/numbers: 使用 Next.js 和 Tailwind CSS
+- Address the reader as 你 (never 您)
+- Occasional casual endings（敬請期待！/ 歡迎跟我聊聊～）
+
+**English (en)**:
+- Simple, direct sentences. Friendly but not slangy.
+- Same structure and headings as the zh version, translated naturally (not literally).
+
+## Mechanics (required)
+
+Files live in `content/posts/`:
+
+- zh-TW: `YYYY-MM-DD-<slug>.mdx` — English version adds `-en`: `YYYY-MM-DD-<slug>-en.mdx`
+- Both language versions share the **same `slug`** — that is how they pair up
+- A post may exist in only one language; the site shows a fallback notice for the other
+
+Frontmatter template:
+
+```yaml
+---
+title: 'Post Title'
+slug: 'kebab-case-slug'
+date: YYYY-MM-DD
+tags: [Project, Productivity]
+category: Project
+socialImage: '/images/<slug>/<slug>-cover.png'
+type: Post
+language: zh-TW # or en
+description: 'One to two sentences, used for SEO, feeds, and post cards.'
+---
+```
+
+- `title`, `slug`, `date`, `description`, `socialImage` are required by the schema
+- `socialImage` can be an absolute URL or a `/images/...` path; an empty string `''` falls back to the generated `/api/og` image
+- Never change the `slug` of a published post; use `redirect_from` if a URL must move
+- Local images go in `public/images/<slug>/`
+
+## Before finishing
+
+1. `pnpm build` must pass (it compiles all MDX and gates on TypeScript)
+2. If the post is bilingual, confirm both files share the slug and each declares the right `language`
+3. Skim `docs/url-baseline.txt` rules in AGENTS.md — new posts only ever ADD URLs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,4 @@ Personal bilingual blog of Eason Chang, deployed on Vercel at https://easonchang
 - TypeScript (strict) + Tailwind CSS. Lint/format via Biome (`biome.json`); pre-commit hook runs lint-staged.
 - Never commit generated output: `.next/`, `.contentlayer/`, `public/sitemap*.xml`, `public/robots.txt`, `public/feed.*`, `public/atom.xml`.
 - Modernization roadmap lives in `docs/MODERNIZATION_PLAN.md`; keep it updated as phases land.
+- Agent skills live in `.claude/skills/`: `write-post` (blog posts in Eason's voice — always use it when drafting post content) and `translate-post` (paired-language versions). `CLAUDE.md` carries Claude-specific rules and the definition-of-done command list.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,31 @@
 See @AGENTS.md for repo architecture, commands, and conventions.
+
+## Claude-specific guidance
+
+### Skills
+
+Prefer these skills over improvising:
+
+- **write-post** (`.claude/skills/write-post/`) — writing any blog post. It encodes Eason's voice, the zh-TW/en language conventions, post structures, and frontmatter mechanics. Always load it before drafting post content.
+- **translate-post** (`.claude/skills/translate-post/`) — creating the paired-language version of an existing post.
+
+### Hard rules
+
+- **URLs are load-bearing.** Every URL in `docs/url-baseline.txt` must keep resolving. Routing changes need re-verification against that file. Never change a published post's `slug`; never remove a `redirect_from`.
+- **Bilingual integrity.** Posts pair by `slug` across `en`/`zh-TW`. UI strings live in `messages/{en,zh-TW}.json` — when adding a key, add it to BOTH files in the same change.
+- **Internal links** in components must go through `@/i18n/navigation`'s `Link` (usually via `CustomLink`), never `next/link` directly, or locale prefixes break.
+- Never commit generated output (`.next/`, `.content-collections/`, `public/sitemap*.xml`, `public/feed.*`, `storybook-static/`).
+
+### Definition of done
+
+Run before declaring any change complete:
+
+```bash
+pnpm lint        # Biome — must be clean
+pnpm test        # Vitest unit tests
+pnpm build       # compiles all MDX, gates on TypeScript strict
+pnpm test:e2e    # Playwright smoke tests (needs the build; in sandboxes set
+                 # PLAYWRIGHT_CHROMIUM_EXECUTABLE=/opt/pw-browsers/chromium)
+```
+
+New AI-facing surface areas to keep in sync with content-model changes: `/llms.txt`, `/llms-full.txt`, `/posts/<slug>.md` (see `src/proxy.ts` and `src/app/llms*`).


### PR DESCRIPTION
Stacked on #34. Makes the repo itself a good place for AI agents to work — not just the published site.

## Agent skills (`.claude/skills/`)

- **`write-post`** — the writing skill. The style guide is derived from analyzing published posts (Timez project post, the Modern Next.js Blog series, both languages), not invented:
  - Voice: first-person, personal motivation first, short 1–3 sentence paragraphs, bold-label feature bullets, generous inline links, sparse emoji, honest status (beta/waitlist), closing call-to-action
  - The two recurring post structures (project posts: 簡介 → Demo & 程式碼 → 為什麼 → 主打功能 → 技術架構; tutorial/series posts with code-diff callouts)
  - zh-TW typography rules:「」quotes, full-width punctuation, CJK↔Latin spacing, tech terms kept in English, reader is 你 — and the matching en conventions
  - Mechanics: file naming (`-en` suffix pairing), frontmatter template, slug immutability, image locations, and the build-verification step
- **`translate-post`** — creates the paired-language version of an existing post: rewrite-in-voice rather than literal translation, structure preserved exactly, locale-specific social handles (`easondev` vs `easondev_tw`) handled.

## CLAUDE.md

Expanded from a one-line AGENTS.md pointer to Claude-specific guidance: the skills roster, hard rules (URL contract via `docs/url-baseline.txt`, bilingual message/slug integrity, i18n-safe `Link` usage, generated-output hygiene), and the definition-of-done command list (`lint` → `test` → `build` → `test:e2e`). AGENTS.md cross-references the skills so non-Claude agents find them too.

Build re-verified green after the change (185 pages).

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpUq2fgkf8uUNXZcXPZtuj)_