### PR TITLE
Modernization 9/9: full Aburi Studio product posts from monorepo PR #326 + DailyWage

### DIFF
--- a/content/pages/about-zh.mdx
+++ b/content/pages/about-zh.mdx
@@ -28,7 +28,7 @@ redirect_from:
 
 我和 [Carol](https://carolhsiao.com) 一起經營 **[Aburi Studio](https://aburistudio.com)**，一間兩人小工作室，為重視時間與金錢的人打造專注的軟體：
 
-- **[CoreHour](https://corehour.app)**——圍繞 80/20 法則設計的極簡時間箱 App（[介紹文](/posts/corehour)）
+- **[CoreHour](https://corehour.app)**——圍繞 80/20 法則設計的極簡時間塊 App（[介紹文](/posts/corehour)）
 - **[FireFree](https://firefree.app)**——追蹤淨資產、預測你的 FIRE 日期（[介紹文](/posts/firefree)）
 - **[天天開薪 DailyWage](https://dailywage.aburi.app)**——即時薪水計算器，還有可愛的像素柯基陪你上班
 

--- a/content/posts/2026-07-28-corehour-en.mdx
+++ b/content/posts/2026-07-28-corehour-en.mdx
@@ -7,32 +7,53 @@ category: Project
 socialImage: '/images/corehour/corehour-og.png'
 type: Post
 language: en
-description: 'CoreHour is a minimalist time-boxing app from Aburi Studio that helps you focus on the 20% of tasks that drive 80% of results. Here is what it does, and why we built it.'
+description: 'CoreHour is a minimalist time-boxing app from Aburi Studio that helps you focus on the 20% of tasks that drive 80% of results. What it does, why we built it, and where it's headed.'
 ---
+
+![CoreHour — Do less. Achieve more.](/images/corehour/corehour-og.png)
+
+## Introduction
 
 For the past while, [Carol](https://carolhsiao.com) and I have been building products together under **[Aburi Studio](https://aburistudio.com)**, our two-person studio based in Calgary. The first product I want to introduce here is **[CoreHour](https://corehour.app)** — a minimalist time-boxing app built around one idea: the 80/20 rule.
 
-## The problem: busy work eats your day
+Its philosophy is printed right on the landing page: **"Do Less. Achieve More."**
+
+## Demo
+
+- **Website:** [corehour.app](https://corehour.app)
+- **Web app:** [app.corehour.app](https://app.corehour.app) — 7-day free trial, no credit card
+- **iOS app:** in the works
+
+## Why we created this project
 
 Most productivity tools are great at collecting tasks, and terrible at telling you a harder truth: not all tasks deserve your time. A day can be completely full and still accomplish nothing that matters.
 
 The Pareto principle says roughly 20% of your tasks drive 80% of your results. The hard part is *seeing* which 20% that is — and actually protecting time for it.
 
-## What CoreHour does
+We were our own victims: growing task lists, stalled important work. So CoreHour asks you to do just three things: set your focus, timebox your day, and track your focus hours.
 
-CoreHour is deliberately simple. It combines time boxing with a focus on high-impact work:
+## Key Features
 
-- **Plan your day visually** — drag and drop tasks into time slots, with color-coded categories, so you can see your entire day at a glance.
-- **Mark what's critical** — flag your high-impact tasks, and track how much of your time goes to them versus busy work.
-- **Learn from your own data** — track your time allocation, monitor focus hours, and discover when you actually work best.
-- **Stay out of your way** — a clean, thoughtfully crafted interface with light and dark modes.
+- **Plan your day visually:** drag and drop tasks into a timeline of 30-minute blocks, with color-coded categories, so you can see your entire day at a glance.
+- **Mark what's critical:** flag your high-impact tasks, and track how much of your time goes to them versus busy work.
+- **Automatic conflict handling:** overlapping time boxes get trimmed, split, or merged automatically — no manual shuffling.
+- **Learn from your own data:** a daily focus-hours goal, streaks, and a weekly breakdown of where your hours really went.
+- **Stay out of your way:** a clean, thoughtfully crafted interface with light and dark modes.
+
+One detail I especially like: the streak has three states, not two. Because CoreHour is a *planner*, qualifying days count backwards and **forwards** — future days can already be planned. If today isn't planned yet but yesterday kept the streak alive, you're in a "planning" state and the UI nudges you instead of showing a broken streak.
 
 That's it. No project management ceremony, no team features you'll never use. It's a daily planning tool for one person: you.
 
+## Technologies
+
+Under the hood, CoreHour is a Next.js web app and an Expo-based iOS app sharing one Supabase backend, with subscriptions handled by RevenueCat. I'll save the deeper engineering stories for future posts.
+
 ## Where it's at
 
-CoreHour is live at **[corehour.app](https://corehour.app)**. If time boxing or the 80/20 rule ever appealed to you, I'd love for you to try it and tell me what's missing.
+CoreHour is live at **[corehour.app](https://corehour.app)**, with a 7-day trial that needs no credit card. An iOS app is in the works.
 
-CoreHour is part of a small family of tools we're building at Aburi Studio around time and money — alongside **FireFree**, a FIRE calculator ([read about it here](/posts/firefree)), and **Daily Wage**, a wage visualizer. More on those soon.
+If time boxing or the 80/20 rule ever appealed to you, I'd love for you to try it and tell me what's missing.
+
+CoreHour is part of a small family of tools we're building at Aburi Studio around time and money — alongside **FireFree**, a FIRE planning app ([read about it here](/posts/firefree)), and **DailyWage**, a real-time salary counter ([read about it here](/posts/dailywage)).
 
 If you have feedback, find me on [X](https://x.com/easondev) or [email me](mailto:eason@easonchang.com) — I read everything.

--- a/content/posts/2026-07-28-corehour.mdx
+++ b/content/posts/2026-07-28-corehour.mdx
@@ -1,5 +1,5 @@
 ---
-title: '打造 CoreHour：圍繞 80/20 法則設計的時間箱 App'
+title: '打造 CoreHour：圍繞 80/20 法則設計的時間塊 App'
 slug: 'corehour'
 date: 2026-07-28
 tags: [Project, Aburi Studio, Productivity, Side Project]
@@ -7,32 +7,53 @@ category: Project
 socialImage: '/images/corehour/corehour-og.png'
 type: Post
 language: zh-TW
-description: 'CoreHour 是 Aburi Studio 打造的極簡時間箱（Time Boxing）App，幫助你專注在驅動 80% 成果的那 20% 任務上。這篇文章介紹它能做什麼、以及我們為什麼做它。'
+description: 'CoreHour 是我們在 Aburi Studio 打造的極簡時間塊（Time Boxing）App，幫助你專注在驅動 80% 成果的那 20% 任務上。介紹它能做什麼、為什麼做它，以及接下來的計畫。'
 ---
 
-這陣子，我和 [Carol](https://carolhsiao.com) 一起以 **[Aburi Studio](https://aburistudio.com)** 的名義打造產品——這是我們兩人在加拿大 Calgary 成立的小工作室。第一個想在這裡介紹的產品是 **[CoreHour](https://corehour.app)**：一款圍繞著「80/20 法則」設計的極簡時間箱（Time Boxing）App。
+![CoreHour — 做得更少，完成更多](/images/corehour/corehour-og.png)
 
-## 問題：瞎忙吃掉你的一天
+## 簡介
+
+這陣子，我和 [Carol](https://carolhsiao.com) 一起以 **[Aburi Studio](https://aburistudio.com)** 的名義打造產品——這是我們兩人在加拿大 Calgary 成立的小工作室。第一個想在這裡介紹的產品是 **[CoreHour](https://corehour.app)**：一款圍繞著「80/20 法則」設計的極簡時間塊（Time Boxing）App。
+
+它的哲學直接印在官網上：**「Do Less. Achieve More.」**
+
+## Demo
+
+- **官網：** [corehour.app](https://corehour.app)
+- **Web 版：** [app.corehour.app](https://app.corehour.app)，7 天免費試用、不用信用卡
+- **iOS 版：** 開發中
+
+## 為什麼我們要開發這個專案
 
 大多數生產力工具都很擅長「收集任務」，卻不擅長告訴你一個更殘酷的事實：不是所有任務都值得你的時間。行程可以排得滿滿的，卻沒完成任何真正重要的事。
 
 帕雷托法則（Pareto Principle）說：大約 20% 的任務，驅動了 80% 的成果。難的是*看見*那 20% 是什麼——並且真的為它保留時間。
 
-## CoreHour 能做什麼
+我們自己就是受害者：待辦清單越長越長，重要的事卻一直卡著。所以 CoreHour 只要求你做三件事：設定焦點、把一天裝進時間塊、追蹤專注時數。
 
-CoreHour 刻意保持簡單，把時間箱方法和「高影響力工作」的視角結合在一起：
+## 主打功能
 
-- **視覺化規劃你的一天**——把任務拖放進時間格，搭配顏色分類，一眼看懂整天的安排。
-- **標記關鍵任務**——把高影響力的任務標記出來，追蹤你的時間花在關鍵工作還是瞎忙上。
-- **從自己的數據中學習**——追蹤時間分配、觀察專注時數，找出你真正效率最高的時段。
-- **不打擾你**——乾淨、細緻的介面，支援明亮與暗黑模式。
+- **視覺化規劃你的一天：** 把任務拖放進 30 分鐘一格的時間軸，搭配顏色分類，一眼看懂整天的安排。
+- **標記關鍵任務：** 把高影響力的任務標記出來，追蹤你的時間花在關鍵工作還是瞎忙上。
+- **自動衝突處理：** 時間塊重疊時自動截短、切割或合併，不用手動喬位置。
+- **從自己的數據中學習：** 每日專注時數目標、連續紀錄（streak）、一週時間分配分析。
+- **不打擾你：** 乾淨、細緻的介面，支援明亮與暗黑模式。
+
+有個細節我特別喜歡：streak 有三種狀態，不是兩種。因為 CoreHour 是「規劃」工具，合格天數往回也**往前**算——未來的日子可以先排好。今天還沒達標但昨天有守住時，你會處在「規劃中」狀態，介面會提醒你把今天排好，而不是給你看一條斷掉的 streak。
 
 就這樣。沒有繁瑣的專案管理流程，也沒有你永遠用不到的團隊功能。它是為一個人設計的每日規劃工具：就是你。
 
+## 技術架構
+
+CoreHour 的 Web 版用 Next.js 打造，iOS 版用 Expo，背後共用同一套 Supabase 後端，訂閱金流則交給 RevenueCat。更深入的工程故事，之後再另外寫文章分享。
+
 ## 目前進度
 
-CoreHour 已經上線，網址是 **[corehour.app](https://corehour.app)**。如果你曾對時間箱或 80/20 法則感興趣，非常歡迎你試用，然後告訴我還缺什麼。
+CoreHour 已經上線，網址是 **[corehour.app](https://corehour.app)**，7 天試用不用信用卡。iOS 版開發中。
 
-CoreHour 是我們在 Aburi Studio 圍繞「時間與金錢」打造的一系列小工具之一——另外還有 FIRE 計算機 **FireFree**（[介紹文在這](/posts/firefree)）和薪資視覺化工具 **Daily Wage**，之後會再多聊聊。
+如果你曾對時間塊或 80/20 法則感興趣，非常歡迎你試用，然後告訴我還缺什麼。
+
+CoreHour 是我們在 Aburi Studio 圍繞「時間與金錢」打造的一系列工具之一——另外還有 FIRE 財務規劃工具 **FireFree**（[介紹文在這](/posts/firefree)）和薪水即時計算器 **天天開薪**（[介紹文在這](/posts/dailywage)）。
 
 有任何回饋，歡迎在 [X](https://x.com/easondev_tw) 上找我，或直接[寄信給我](mailto:eason@easonchang.com)——每一封我都會看。

--- a/content/posts/2026-07-28-firefree-en.mdx
+++ b/content/posts/2026-07-28-firefree-en.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'FireFree: Tracking the Path to Financial Freedom'
+title: 'FireFree: A FIRE Planning App That Calms Your Money Anxiety'
 slug: 'firefree'
 date: 2026-07-28
 tags: [Project, Aburi Studio, FIRE, Finance, Side Project]
@@ -7,27 +7,52 @@ category: Project
 socialImage: '/images/firefree/firefree-og-en.png'
 type: Post
 language: en
-description: 'FireFree is the FIRE tool we are building at Aburi Studio: track your net worth, project your FIRE date, and watch financial independence become a concrete plan instead of a vague dream. Try it at firefree.app.'
+description: 'FireFree is the FIRE planning app we built at Aburi Studio: no expense logging, no bank linking — just track your net worth and see the day you reach financial freedom. Free to sign up, with a no-account demo mode.'
 ---
 
-The second product we're building at **[Aburi Studio](https://aburistudio.com)** is the one closest to my own life: **[FireFree](https://firefree.app)**, a tool for tracking your path to financial freedom.
+![FireFree — Calm your money anxiety](/images/firefree/firefree-og-en.png)
 
-## Why a FIRE tool
+## Introduction
 
-FIRE — *Financial Independence, Retire Early* — sounds like a dream until you turn it into numbers. Then it becomes something much more useful: a plan. How much do you own? How fast is it growing? At your current pace, when exactly could work become optional?
+The second product we're building at **[Aburi Studio](https://aburistudio.com)** is the one closest to my own life: **[FireFree](https://firefree.app)**, a FIRE (Financial Independence, Retire Early) planning app.
 
-FireFree started as a tool we needed ourselves. [Carol](https://carolhsiao.com) and I have been planning our own financial future, and spreadsheets only take you so far: they don't show momentum, and they don't answer the only question that really matters — *when?* We built FireFree for ourselves first, and now we're sharing what works.
+It answers one deceptively simple question: "If I keep living the way I live now, when can I stop working?"
 
-## What FireFree does
+## Demo
 
-- **Track your net worth** — one clear picture of what you own, kept up to date.
-- **Project your FIRE date** — see when you can realistically reach financial independence, based on your actual numbers.
-- **Visualize the journey** — watch your progress toward financial independence become real over time, instead of living in a spreadsheet you dread opening.
+- **Website:** [firefree.app](https://firefree.app)
+- **Demo mode:** no sign-up needed — enter the full product from the landing page, with six preset financial scenarios to explore
+- **Languages:** full English / Traditional Chinese support
 
-Like everything we make at Aburi Studio, the goal is focused software: one job, done simply and beautifully.
+## Why we created this project
+
+FIRE sounds like a dream until you turn it into numbers. Then it becomes something much more useful: a plan.
+
+[Carol](https://carolhsiao.com) and I have been planning our own financial future, and spreadsheets only take you so far: they don't show momentum, and they don't answer the only question that really matters — *when?*
+
+We also noticed that money anxiety rarely comes from not knowing what you spent last Tuesday. It comes from **not being able to see the future**. You save a few hundred dollars a month with no idea whether it's enough; your banking app shows a cold balance and nothing tells you how long it would last.
+
+So FireFree deliberately rejects two things: **no expense logging** (update your assets once a month, in minutes) and **no bank linking** (enter rough numbers yourself — your data stays yours). What you get in return is a map of your future.
+
+## Key Features
+
+- **FIRE forecast:** your income, expenses, assets, and debts, with compound growth and inflation applied — drawn as the curve where your net worth crosses your FIRE number, with your projected FIRE age on it. Based on the classic 4% rule; multiplier, withdrawal rate, and inflation are all adjustable.
+- **Asset tracking without bookkeeping:** savings, investments, real assets, and debts, each with value history. Watching the curve climb is genuinely satisfying.
+- **Life goals you can toggle:** add "buy a home" or "one big trip a year", flip each goal on and off, and watch your FIRE date shift. Abstract trade-offs become a visible curve.
+- **Automatic stock price sync:** link holdings to tickers (US and Taiwan markets) and daily jobs keep valuations fresh.
+- **Multi-currency:** accounts in USD, TWD, EUR… converted into one display currency.
+- **Privacy mode:** one eye icon turns every amount into `$•,•••.••` — share your screen without sharing your net worth.
+
+## Technologies
+
+FireFree is a Next.js web app — a PWA that works offline — backed by Supabase, and all the FIRE math lives in one shared TypeScript package so every screen shows exactly the same numbers. The deeper engineering stories deserve their own posts someday.
 
 ## Where it's at
 
-FireFree is live at **[firefree.app](https://firefree.app)** — you can even explore the demo without creating an account.
+FireFree is live and open for free sign-ups — there's a free plan you can stay on. An iOS app is in the works.
 
-If FIRE is on your mind — whether you're deep into the movement or just want to know your number — [give it a try](https://firefree.app), and tell me what you'd want such a tool to do. And if daily planning is more your thing, check out our other product [CoreHour](/posts/corehour).
+If FIRE is on your mind — whether you're deep into the movement or just want to know your number — [playing with the demo](https://firefree.app) is the fastest way in: no account, pick a scenario, explore the full product.
+
+FireFree is part of a small family of tools we're building at Aburi Studio around time and money — alongside **CoreHour**, a minimalist time-boxing app ([read about it here](/posts/corehour)), and **DailyWage**, a real-time salary counter ([read about it here](/posts/dailywage)).
+
+If you have feedback, find me on [X](https://x.com/easondev) or [email me](mailto:eason@easonchang.com) — I read everything.

--- a/content/posts/2026-07-28-firefree.mdx
+++ b/content/posts/2026-07-28-firefree.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'FireFree：追蹤你通往財務自由的路'
+title: 'FireFree：告別理財焦慮的 FIRE 財務規劃工具'
 slug: 'firefree'
 date: 2026-07-28
 tags: [Project, Aburi Studio, FIRE, Finance, Side Project]
@@ -7,27 +7,52 @@ category: Project
 socialImage: '/images/firefree/firefree-og-zh-TW.png'
 type: Post
 language: zh-TW
-description: 'FireFree 是我們在 Aburi Studio 打造的 FIRE 工具：追蹤淨資產、預測你的 FIRE 日期，讓財務自由從模糊的夢想變成具體的計畫。歡迎到 firefree.app 試用。'
+description: 'FireFree 是我們在 Aburi Studio 打造的 FIRE 財務規劃工具：不用記帳、不用串接銀行，就能追蹤淨資產、預測你達成財務自由的那一天。已開放免費註冊，也可以直接玩 Demo 模式。'
 ---
 
-我們在 **[Aburi Studio](https://aburistudio.com)** 打造的第二個產品，也是和我自己的人生最相關的一個：**[FireFree](https://firefree.app)**，一個幫你追蹤「通往財務自由之路」的工具。
+![FireFree — 告別理財焦慮](/images/firefree/firefree-og-zh-TW.png)
 
-## 為什麼做 FIRE 工具
+## 簡介
 
-FIRE——*Financial Independence, Retire Early*（財務獨立、提早退休）——在化成數字之前，聽起來像個遙遠的夢。但一旦變成數字，它就成了更有用的東西：一個計畫。你現在擁有多少？成長得多快？照目前的速度，究竟哪一天「工作」可以變成一種選擇？
+我們在 **[Aburi Studio](https://aburistudio.com)** 打造的第二個產品，也是和我自己的人生最相關的一個：**[FireFree](https://firefree.app)**，一個 FIRE（財務獨立、提早退休）財務規劃工具。
 
-FireFree 一開始就是我們自己需要的工具。我和 [Carol](https://carolhsiao.com) 一直在規劃自己的財務未來，但試算表能做的有限：它看不出動能，也回答不了唯一真正重要的問題——*什麼時候？* 我們先為自己打造了 FireFree，現在把有用的部分分享出來。
+它想回答一個看似簡單的問題：「照現在這樣過日子，我到底哪一天可以不用再為錢工作？」
 
-## FireFree 能做什麼
+## Demo
 
-- **追蹤淨資產**——你所擁有的一切，一張清楚的全貌。
-- **預測你的 FIRE 日期**——根據你真實的數字，看見何時能實際達到財務獨立。
-- **視覺化整段旅程**——看著自己朝財務自由前進的軌跡，而不是活在一份你不想打開的試算表裡。
+- **官網：** [firefree.app](https://firefree.app)
+- **Demo 模式：** 不用註冊，從官網就能進入完整產品，內建六種財務情境隨你玩
+- **語言：** 繁體中文 / English 完整支援
 
-和 Aburi Studio 的每個產品一樣，我們的目標是「專注的軟體」：把一件事做得簡單而漂亮。
+## 為什麼我們要開發這個專案
+
+FIRE 在化成數字之前，聽起來像個遙遠的夢。但一旦變成數字，它就成了更有用的東西：一個計畫。
+
+我和 [Carol](https://carolhsiao.com) 一直在規劃自己的財務未來，但試算表能做的有限：它看不出動能，也回答不了唯一真正重要的問題——*什麼時候？*
+
+我們也發現，對錢的焦慮很少來自「不知道上週二花了多少」，而是來自**看不見未來**。每個月省下幾百塊，卻不知道到底夠不夠退休；打開銀行 App 只有冰冷的餘額，沒有人告訴你這筆錢能撐多久。
+
+所以 FireFree 刻意放棄了兩件事：**不記帳**（每月花幾分鐘更新一次資產就好），**不串接銀行**（數字自己填大概的就行，資料完全屬於你）。換來的是一張未來的地圖。
+
+## 主打功能
+
+- **財務自由預測：** 根據收支、資產與負債，套上複利與通膨，畫出淨資產曲線與 FIRE 目標曲線的交會點，直接標出你預計幾歲 FIRE。計算基礎是經典的 4% 法則，倍數、提領率、通膨率全部可調。
+- **不用記帳的資產追蹤：** 存款、投資、實體資產、負債四大類，每筆都有歷史紀錄，看著淨資產慢慢攀升很有成就感。
+- **可以開關的人生目標：** 新增「買房」、「每年一趟大旅行」，在圖表上開開關關，看 FIRE 日期怎麼移動。抽象的取捨變成看得見的曲線。
+- **股價自動同步：** 持股綁定代號（支援美股與台股），每天自動更新市值。
+- **多幣別支援：** USD、TWD、EUR 帳戶通通換算成同一個顯示幣別。
+- **隱私模式：** 點一下眼睛圖示，全 App 金額變成 `$•,•••.••`，開會投影不怕曝光淨資產。
+
+## 技術架構
+
+FireFree 的 Web 版用 Next.js 打造（支援離線的 PWA），後端是 Supabase；所有 FIRE 數學都放在同一個共用的 TypeScript package 裡，每個畫面顯示的數字保證一致。更深入的工程故事，之後再另外寫文章分享。
 
 ## 目前進度
 
-FireFree 已經上線：**[firefree.app](https://firefree.app)**，不用註冊也能先逛逛 Demo。
+FireFree 已經上線，開放免費註冊，也有免費方案可以一直用。iOS 版開發中。
 
-如果你也在想 FIRE 這件事——無論你已經深入研究、還是只想知道自己的「FIRE 數字」——歡迎[實際試用](https://firefree.app)，並告訴我你希望這樣的工具能做什麼。如果你更在意每天的時間規劃，也可以看看我們的另一個產品 [CoreHour](/posts/corehour)。
+如果你也在想 FIRE 這件事——無論你已經深入研究、還是只想知道自己的「FIRE 數字」——[直接玩玩 Demo](https://firefree.app) 是最快的方式：不用註冊，選一個財務情境就能體驗完整產品。
+
+FireFree 是我們在 Aburi Studio 圍繞「時間與金錢」打造的一系列工具之一——另外還有極簡時間塊 App **CoreHour**（[介紹文在這](/posts/corehour)）和薪水即時計算器 **天天開薪**（[介紹文在這](/posts/dailywage)）。
+
+有任何回饋，歡迎在 [X](https://x.com/easondev_tw) 上找我，或直接[寄信給我](mailto:eason@easonchang.com)——每一封我都會看。

--- a/content/posts/2026-07-29-dailywage-en.mdx
+++ b/content/posts/2026-07-29-dailywage-en.mdx
@@ -1,0 +1,55 @@
+---
+title: 'Building DailyWage: A Real-Time Salary Counter with a Corgi Companion'
+slug: 'dailywage'
+date: 2026-07-29
+tags: [Project, Aburi Studio, iOS, React Native, Side Project]
+category: Project
+socialImage: '/images/dailywage/dailywage-og-en.png'
+type: Post
+language: en
+description: 'DailyWage is a free iOS app from Aburi Studio that shows your salary ticking up every 100 ms, with a pixel corgi companion, tap-to-save goals, and widgets. No backend — your data never leaves your device.'
+---
+
+![DailyWage — watch your salary tick](/images/dailywage/dailywage-og-en.png)
+
+## Introduction
+
+**[DailyWage](https://dailywage.aburi.app)** is the third product [Carol](https://carolhsiao.com) and I built at **[Aburi Studio](https://aburistudio.com)** — the smallest and most playful one, and weirdly, the one with some of the most interesting engineering.
+
+It answers a question every office worker has asked at 3 p.m. on a Wednesday: "How much have I actually earned *so far today*?" (In Chinese it's called **天天開薪** — a pun on 天天開心, "happy every day".)
+
+## Demo
+
+- **Website:** [dailywage.aburi.app](https://dailywage.aburi.app)
+- **App Store:** [free download](https://apps.apple.com/app/id6758375748) (iOS; Android is on the roadmap)
+- **Languages:** English / Traditional Chinese
+
+## Why we created this project
+
+People work for their goals and dreams, but the daily grind makes it easy to want to give up.
+
+Your salary is a number that appears at the end of the month — too far removed from these three hours this afternoon. What if you could *see* time turning into money, every single second? Would the workday feel a little more worth it?
+
+So we built a small, comforting tool: enter your monthly salary and working hours, and it updates your earnings **every 100 milliseconds**, four decimal places and all, while a pixel-art corgi keeps you company. Outside working hours and on weekends, the corgi sleeps.
+
+## Key Features
+
+- **Real-time earnings counter:** ticks every 100 ms while you watch your money grow.
+- **Tap-to-save goals:** create goals — "Trip to Japan", an emergency fund — and tap a card to allocate today's earnings into it — long-press to allocate continuously. Completed goals get stamped with a traditional ink-seal animation.
+- **Monthly rhythm:** a monthly progress bar fills as the month goes on, and goals marked as fixed expenses (rent!) reset automatically on the 1st.
+- **Widgets:** today's earnings and monthly progress tick along on your home screen and lock screen — with working, sleeping, and celebrating corgi variants.
+- **100% private:** no accounts, no cloud. All financial data stays on your device, and the app is completely free with no ads.
+
+## Technologies
+
+DailyWage is an Expo (React Native) app with SwiftUI widgets — and deliberately **no backend**: everything stays on your device. My favorite development detail: you can't QA a watch-your-salary-all-day app in real time, so dev mode can run the clock at 720× — a full 24-hour workday plays out in two minutes.
+
+## Where it's at
+
+DailyWage is [live on the App Store](https://apps.apple.com/app/id6758375748), completely free with no ads, and Android is on the roadmap.
+
+If your workday could use a corgi and a satisfying number going up, give it a try — and if it makes you smile at 3 p.m. on a Wednesday, it did its job.
+
+DailyWage is part of a small family of tools we're building at Aburi Studio around time and money — alongside **CoreHour**, a minimalist time-boxing app ([read about it here](/posts/corehour)), and **FireFree**, a FIRE planning app ([read about it here](/posts/firefree)).
+
+If you have feedback, find me on [X](https://x.com/easondev) or [email me](mailto:eason@easonchang.com) — I read everything.

--- a/content/posts/2026-07-29-dailywage.mdx
+++ b/content/posts/2026-07-29-dailywage.mdx
@@ -1,0 +1,55 @@
+---
+title: '打造「天天開薪」：柯基陪你上班、薪水一秒一秒進帳的療癒小 App'
+slug: 'dailywage'
+date: 2026-07-29
+tags: [Project, Aburi Studio, iOS, React Native, Side Project]
+category: Project
+socialImage: '/images/dailywage/dailywage-og-zh-TW.png'
+type: Post
+language: zh-TW
+description: '天天開薪（DailyWage）是我們在 Aburi Studio 打造的免費 iOS App：每 100 毫秒更新你今天賺到的薪水，一隻像素柯基陪你上班，還能輕觸把收入分配進存錢目標。沒有後端，資料完全不離開你的手機。'
+---
+
+![天天開薪 — 看著薪水一秒一秒進帳](/images/dailywage/dailywage-og-zh-TW.png)
+
+## 簡介
+
+**[天天開薪](https://dailywage.aburi.app)**（DailyWage）是我和 [Carol](https://carolhsiao.com) 在 **[Aburi Studio](https://aburistudio.com)** 打造的第三個產品——最小、最玩心大發，但意外地，也是工程細節最有趣的一個。
+
+它回答每個上班族週三下午三點都問過的問題：「到現在為止，我今天到底賺了多少錢？」名字是「天天開心」的諧音——我們希望上班的煩悶裡，至少有個東西讓你每天開薪（心）😆
+
+## Demo
+
+- **官網：** [dailywage.aburi.app](https://dailywage.aburi.app)
+- **App Store：** [免費下載](https://apps.apple.com/app/id6758375748)（iOS；Android 在路線圖上）
+- **語言：** 繁體中文 / English
+
+## 為什麼我們要開發這個專案
+
+我們發現大家是為了目標跟夢想而上班，但上班帶來的煩悶跟厭倦感，卻讓人很想放棄。
+
+薪水是月底才出現的一個數字，跟今天下午這三個小時的關係太遙遠了。如果能*看見*時間正在變成錢——每一秒都在——上班會不會有動力一點？
+
+於是我們做了一個療癒小工具：輸入月薪和上班時間，它就**每 100 毫秒**更新一次你今天賺到的錢，小數點後四位都給你看，旁邊一隻像素柯基陪你上班。下班時間和週末，柯基會睡覺。
+
+## 主打功能
+
+- **即時薪水計算：** 每 100 毫秒跳動一次，看著自己賺到的錢一點一點長大。
+- **輕觸存錢目標：** 建立「日本旅遊」、緊急預備金等目標，點一下卡片就把今天賺到的錢分配進去，長按還能連續分配。目標達成時會蓋上一顆篆刻印章動畫。
+- **每月的節奏：** 本月累積進度條慢慢填滿；標成「每月固定支出」的目標（房租！）每月 1 號自動歸零。
+- **桌面小工具：** 今日收入和本月進度直接在主畫面與鎖定畫面上跳動，柯基也有上班、睡覺、慶祝三種型態。
+- **100% 隱私：** 沒有帳號、沒有雲端，所有財務資料只存在你的裝置上，完全免費、沒有廣告。
+
+## 技術架構
+
+天天開薪是用 Expo（React Native）打造的 App，搭配 SwiftUI 小工具，而且**刻意不做後端**——所有資料只存在你的裝置上。我最喜歡的開發細節：「盯著薪水跳一整天」沒辦法用真實時間 QA，所以開發者模式可以把時鐘加速 720 倍，24 小時的工作日兩分鐘演完。
+
+## 目前進度
+
+天天開薪已經在 [App Store 上架](https://apps.apple.com/app/id6758375748)，完全免費、沒有廣告，Android 版在路線圖上。
+
+如果你的上班日需要一隻柯基和一個持續上升的數字，來試試看——如果它讓你在週三下午三點笑出來，它的任務就完成了。
+
+天天開薪是我們在 Aburi Studio 圍繞「時間與金錢」打造的一系列工具之一——另外還有極簡時間塊 App **CoreHour**（[介紹文在這](/posts/corehour)）和 FIRE 財務規劃工具 **FireFree**（[介紹文在這](/posts/firefree)）。
+
+有任何回饋，歡迎在 [X](https://x.com/easondev_tw) 上找我，或直接[寄信給我](mailto:eason@easonchang.com)——每一封我都會看。

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -29,9 +29,9 @@ export type Project = {
 export const PROJECTS_ZH = <Project[]>[
   // CoreHour (Aburi Studio)
   {
-    title: 'CoreHour - 80/20 法則時間箱 App',
+    title: 'CoreHour - 80/20 法則時間塊 App',
     description:
-      '極簡的時間箱（Time Boxing）App，幫助你專注在驅動 80% 成果的那 20% 任務上。拖放任務到時間格、標記關鍵任務、追蹤專注時數。由 Aburi Studio 打造。',
+      '極簡的時間塊（Time Boxing）App，幫助你專注在驅動 80% 成果的那 20% 任務上。拖放任務到時間格、標記關鍵任務、追蹤專注時數。由 Aburi Studio 打造。',
     links: {
       post: '/posts/corehour',
       github: '',
@@ -39,7 +39,7 @@ export const PROJECTS_ZH = <Project[]>[
     },
     image: {
       src: '/images/corehour/corehour-og.png',
-      alt: 'CoreHour - 時間箱 App',
+      alt: 'CoreHour - 時間塊 App',
       placeholder: 'empty',
     },
   },
@@ -47,7 +47,7 @@ export const PROJECTS_ZH = <Project[]>[
   {
     title: 'FireFree - 財務自由追蹤工具',
     description:
-      '追蹤淨資產、預測你的 FIRE 日期、視覺化通往財務自由的旅程。我們先為自己打造、再分享出來的工具。由 Aburi Studio 打造，現已上線。',
+      '不用記帳、不用串接銀行的 FIRE 財務規劃工具：追蹤淨資產、預測你的 FIRE 日期、視覺化通往財務自由的旅程。由 Aburi Studio 打造，公開測試中，可直接體驗 Demo。',
     links: {
       post: '/posts/firefree',
       github: '',
@@ -65,7 +65,7 @@ export const PROJECTS_ZH = <Project[]>[
     description:
       '每 100 毫秒更新你今天賺到的薪水，像素柯基陪你上班。輕觸把收入分配進存錢目標，桌面小工具持續跳動。免費、無廣告、沒有後端——資料不離開你的手機。由 Aburi Studio 打造。',
     links: {
-      post: '',
+      post: '/posts/dailywage',
       github: '',
       site: 'https://dailywage.aburi.app',
     },
@@ -286,7 +286,7 @@ export const PROJECTS_EN = <Project[]>[
   {
     title: 'FireFree - Track Your Path to Financial Freedom',
     description:
-      'Track your net worth, project your FIRE date, and visualize your journey to financial independence. A tool we built for ourselves first. Built at Aburi Studio, live now.',
+      'A FIRE planning app with no expense logging and no bank linking: track your net worth, project your FIRE date, and visualize your journey to financial independence. Built at Aburi Studio, live now, with a no-account demo.',
     links: {
       post: '/posts/firefree',
       github: '',
@@ -304,7 +304,7 @@ export const PROJECTS_EN = <Project[]>[
     description:
       'Watch your salary tick up every 100 ms while a pixel corgi keeps you company. Tap to allocate earnings into savings goals; widgets keep counting on your lock screen. Free, no ads, and no backend — your data never leaves your device. Built at Aburi Studio.',
     links: {
-      post: '',
+      post: '/posts/dailywage',
       github: '',
       site: 'https://dailywage.aburi.app',
     },


### PR DESCRIPTION
## What this PR does

Publishes the full bilingual write-ups for the three Aburi Studio products — replacing the CoreHour/FireFree teaser posts and adding DailyWage. Last PR of the modernization stack.

- **CoreHour** (`/posts/corehour`, en + zh-TW): the 80/20 time-boxing story — why we built it, the visual day-planner features, the three-state streak. Live on the web with a 7-day no-card trial; iOS app noted as in the works.
- **FireFree** (`/posts/firefree`, en + zh-TW): the FIRE planning story — no expense logging, no bank linking, life-goal toggles, the projected FIRE-date curve. Live and free to sign up, with the no-account demo; iOS app noted as in the works.
- **DailyWage 天天開薪** (`/posts/dailywage`, en + zh-TW, new): the real-time salary counter with the corgi companion — free on the [App Store](https://apps.apple.com/app/id6758375748). Its project entry gains the "Learn more" post link.
- Copy is kept tight and durable: technical detail is one short stack paragraph per post, feature lists are pruned of micro-details (no tabular-numerals/Lottie/PWA-offline bullets), and zh-TW wording uses 時間塊 for time boxing (also applied to the project entry and about page). Posts use the **product OG images already in the repo** — no new cover art, no architecture diagrams, zero image files in this diff.

## Stack

Merge in order — each PR contains only its own diff. This is the last one:

1. ✅ #38 Safety net *(merged)*
2. ✅ #43 Next.js 16 App Router *(merged)*
3. ✅ #44 Biome, Storybook 10, Vitest + Playwright *(merged)*
4. ✅ #45 UI refresh *(merged)*
5. ✅ #46 AI-readable endpoints *(merged)*
6. ✅ #47 Polish *(merged)*
7. ✅ #48 Content refresh *(merged)*
8. ✅ #49 AI-ready repo *(merged)*
9. **#50 Full Aburi product posts ← this PR** (base: `main`)

## Result

- Tiny final diff: **8 files, +258/−56** — six post files, the project entry, and one about-page line.
- Gates: `pnpm lint` clean (Biome), **23/23** unit tests, **187-page** static build, **17/17** Playwright smoke tests.
- URL contract intact; the new `/posts/dailywage` pages flow into sitemap, feeds, `/llms.txt`, and the raw-markdown routes automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpUq2fgkf8uUNXZcXPZtuj