### PR TITLE
List every profile in the Person JSON-LD's sameAs

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -14,7 +14,7 @@ import LayoutWrapper from '@/components/LayoutWrapper';
 import CommandPalette from '@/components/organisms/CommandPalette';
 import { NEXT_PUBLIC_GOOGLE_ANALYTICS } from '@/constants/envValues';
 import siteMetadata from '@/data/siteMetadata';
-import { getSocialLinks } from '@/data/socialLinks';
+import { allProfileUrls, getSocialLinks } from '@/data/socialLinks';
 import { routing } from '@/i18n/routing';
 import { allPostsOfLocaleNewToOld } from '@/lib/content';
 import { languageAlternates, localizedUrl } from '@/lib/seo';
@@ -125,8 +125,6 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
 
   const messages = await getMessages();
 
-  const social = getSocialLinks(locale);
-
   const commandPalettePosts = allPostsOfLocaleNewToOld(locale).map((post) => ({
     slug: post.slug,
     title: post.title,
@@ -151,16 +149,8 @@ export default async function LocaleLayout({ children, params }: LayoutProps) {
         name: siteMetadata.author,
         url: siteMetadata.siteUrl,
         image: siteMetadata.siteUrl + siteMetadata.siteLogo,
-        email: social.email,
-        sameAs: [
-          social.github,
-          social.linkedin,
-          social.twitter,
-          social.facebook,
-          social.instagram,
-          social.threads,
-          social.bluesky,
-        ],
+        email: siteMetadata.email,
+        sameAs: allProfileUrls,
       },
     ],
   };

--- a/src/data/socialLinks.test.ts
+++ b/src/data/socialLinks.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
-import { getSocialLinks } from '@/data/socialLinks';
+import { allProfileUrls, getSocialLinks } from '@/data/socialLinks';
 
 /**
  * Every markdown link target on a page, trailing slash normalized away.
@@ -40,5 +40,27 @@ describe('getSocialLinks', () => {
 
   it('falls back to the English accounts for an unknown locale', () => {
     expect(getSocialLinks('de')).toEqual(getSocialLinks('en'));
+  });
+});
+
+describe('allProfileUrls', () => {
+  it('covers both locales, so one sameAs list identifies the whole person', () => {
+    for (const locale of ['en', 'zh-TW']) {
+      const { twitterID, email, ...profiles } = getSocialLinks(locale);
+
+      for (const [platform, url] of Object.entries(profiles)) {
+        expect(allProfileUrls, `${locale} ${platform}`).toContain(url);
+      }
+    }
+  });
+
+  it('lists each profile once', () => {
+    expect(allProfileUrls).toEqual([...new Set(allProfileUrls)]);
+  });
+
+  it('carries no @handles, which are not resolvable URLs', () => {
+    for (const url of allProfileUrls) {
+      expect(url).toMatch(/^https:\/\//);
+    }
   });
 });

--- a/src/data/socialLinks.ts
+++ b/src/data/socialLinks.ts
@@ -46,3 +46,20 @@ export const getSocialLinks = (locale: string): SocialLinks => ({
   linkedin: siteMetadata.linkedin,
   ...(locale === 'zh-TW' ? localizedAccounts['zh-TW'] : localizedAccounts.en),
 });
+
+/**
+ * Every profile URL Eason owns, both audiences' accounts together, for the
+ * Person JSON-LD's `sameAs`.
+ *
+ * Deliberately not localized: `sameAs` is an identity graph rather than a link
+ * for readers, and both locales publish the same Person `@id`. Emitting a
+ * different half of the set per page would have the two pages disagree about
+ * one entity and show any given crawl only part of it.
+ */
+export const allProfileUrls: string[] = [
+  siteMetadata.github,
+  siteMetadata.linkedin,
+  ...Object.values(localizedAccounts).flatMap(({ twitterID, ...urls }) =>
+    Object.values(urls)
+  ),
+];


### PR DESCRIPTION
Follow-up to #58, which localized the social links. That change also localized the `Person` JSON-LD's `sameAs` list, which on reflection is the one place localizing was counterproductive.

## Why

Both locales publish the same Person `@id` (`https://easonchang.com/#person`) — one entity — but each page emitted only its own audience's five accounts. So the two pages disagreed about a single `@id`, and any given crawl saw half the identity graph.

`sameAs` is an identity graph for crawlers, not a link for readers, so there is nothing to localize about it: every account is Eason's regardless of which page it appears on, and more of them means better entity disambiguation. `allProfileUrls` now lists all twelve profiles on every page.

Everything reader-facing stays per-locale — footer, contact card, hero paragraph, and the `twitter:creator` / `twitter:site` handle. A zh-TW visitor still goes to `@easondev_tw`.

## Also

`LocaleLayout` no longer resolves social links at all. After this change the only value it still needed was the shared email, which comes straight from `siteMetadata`.

## Testing

- `pnpm lint` — clean
- `pnpm test` — 30 passed
- `pnpm build` — compiles
- `pnpm test:e2e` — 17 passed

Three new assertions cover the union: it contains every profile from both locales, lists each once, and carries no `@handle` strings (`twitterID` is Twitter-card meta, not a resolvable URL). Each was mutation-tested rather than trusted green — restricting the union to the English accounts fails the coverage test, and letting `twitterID` through fails the URL test.

Verified on the built site: `sameAs` is identical across `/`, `/zh-TW`, `/about`, `/zh-TW/about`, and `/posts`, while `twitter:creator` and the footer hrefs remain per-locale.

No routing or content-model changes, so `docs/url-baseline.txt` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EUtrMzpfat1D33f9GsWfLX

---
_Generated by [Claude Code](https://claude.ai/code/session_01EUtrMzpfat1D33f9GsWfLX)_