### PR TITLE
Raise text contrast to WCAG AA, and revive the dead .prose style block

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -117,7 +117,7 @@ export default async function HomePage({ params }: PageProps) {
       {/* Contact */}
       <FadeIn delay={0.05}>
         <section className="bento-card flex h-full flex-col gap-5 p-8">
-          <h2 className="text-sm font-medium uppercase tracking-wider text-gray-400">
+          <h2 className="text-sm font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
             {t('contact-title')}
           </h2>
           <p className="text-gray-600 dark:text-gray-300">
@@ -126,7 +126,7 @@ export default async function HomePage({ params }: PageProps) {
           <div className="flex flex-wrap gap-3">
             <a
               href={`mailto:${social.email}`}
-              className="rounded-full bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-500"
+              className="rounded-full bg-primary-700 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-primary-800"
             >
               {t('email-me')}
             </a>
@@ -134,7 +134,7 @@ export default async function HomePage({ params }: PageProps) {
               href="https://fantastical.app/easonchang/chat"
               target="_blank"
               rel="noreferrer"
-              className="rounded-full border border-gray-900/10 px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:border-primary-500/40 hover:text-primary-600 dark:border-white/10 dark:text-gray-200 dark:hover:text-primary-400"
+              className="rounded-full border border-gray-900/10 px-5 py-2.5 text-sm font-semibold text-gray-700 transition-colors hover:border-primary-500/40 hover:text-primary-700 dark:border-white/10 dark:text-gray-200 dark:hover:text-primary-400"
             >
               {t('book-time')}
             </a>
@@ -167,7 +167,7 @@ export default async function HomePage({ params }: PageProps) {
       {/* Featured projects */}
       <FadeIn delay={0.15} className="md:col-span-2 lg:col-span-3">
         <section className="bento-card h-full p-8">
-          <h2 className="flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-gray-400">
+          <h2 className="flex items-center gap-2 text-sm font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
             <Image
               src="/images/aburi-studio-logo.png"
               alt=""
@@ -199,7 +199,7 @@ export default async function HomePage({ params }: PageProps) {
                       placeholder={project.image.placeholder}
                     />
                   </div>
-                  <p className="mt-3 font-semibold text-gray-900 transition-colors group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
+                  <p className="mt-3 font-semibold text-gray-900 transition-colors group-hover:text-primary-700 dark:text-gray-100 dark:group-hover:text-primary-400">
                     {project.title.split(' - ')[0]}
                   </p>
                   <p className="mt-1 line-clamp-2 text-sm text-gray-500 dark:text-gray-400">
@@ -213,7 +213,7 @@ export default async function HomePage({ params }: PageProps) {
             <CustomLink
               href="/projects"
               aria-label="all projects"
-              className="group/link inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 transition-colors hover:text-primary-500 dark:text-primary-400"
+              className="group/link inline-flex items-center gap-1.5 text-sm font-medium text-primary-700 transition-colors hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300"
             >
               {tCommon('view-all-projects', { count: projects.length })}
               <span
@@ -230,7 +230,7 @@ export default async function HomePage({ params }: PageProps) {
       {/* Latest posts */}
       <FadeIn delay={0.2} className="md:col-span-2 lg:col-span-3">
         <section className="bento-card h-full p-8">
-          <h2 className="text-sm font-medium uppercase tracking-wider text-gray-400">
+          <h2 className="text-sm font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
             {t('latest-posts')}
           </h2>
           <ul className="mt-2 divide-y divide-gray-900/5 dark:divide-white/5">
@@ -243,11 +243,11 @@ export default async function HomePage({ params }: PageProps) {
                   <div className="min-w-0 flex-1">
                     <time
                       dateTime={post.date}
-                      className="block text-xs font-medium uppercase tracking-wider text-gray-400"
+                      className="block text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
                     >
                       {formatDate(post.date, locale)}
                     </time>
-                    <h3 className="mt-1 line-clamp-2 font-semibold text-gray-900 transition-colors group-hover:text-primary-600 dark:text-gray-100 dark:group-hover:text-primary-400">
+                    <h3 className="mt-1 line-clamp-2 font-semibold text-gray-900 transition-colors group-hover:text-primary-700 dark:text-gray-100 dark:group-hover:text-primary-400">
                       {post.title}
                     </h3>
                     {post.description && (
@@ -272,7 +272,7 @@ export default async function HomePage({ params }: PageProps) {
             <CustomLink
               href="/posts"
               aria-label="all posts"
-              className="group/link inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 transition-colors hover:text-primary-500 dark:text-primary-400"
+              className="group/link inline-flex items-center gap-1.5 text-sm font-medium text-primary-700 transition-colors hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300"
             >
               {tCommon('view-all-posts', { count: posts.length })}
               <span

--- a/src/components/CustomPre.tsx
+++ b/src/components/CustomPre.tsx
@@ -56,7 +56,7 @@ function CustomPre({ children, className, ...props }: Props) {
               'hidden rounded-md border bg-transparent p-2 transition ease-in focus:outline-none group-hover:flex',
               {
                 'border-green-400': copied,
-                'border-gray-600 hover:border-gray-400 focus:ring-4 focus:ring-gray-200/50 dark:border-gray-700 dark:hover:border-gray-400':
+                'border-gray-600 hover:border-gray-500 focus:ring-4 focus:ring-gray-200/50 dark:border-gray-400 dark:hover:border-gray-300':
                   !copied,
               }
             )}
@@ -65,7 +65,7 @@ function CustomPre({ children, className, ...props }: Props) {
               aria-hidden="true"
               xmlns="http://www.w3.org/2000/svg"
               className={clsx('pointer-events-none h-4 w-4', {
-                'text-gray-400 dark:text-gray-400': !copied,
+                'text-gray-500 dark:text-gray-400': !copied,
                 'text-green-400': copied,
               })}
               fill="none"

--- a/src/components/PromoCard.tsx
+++ b/src/components/PromoCard.tsx
@@ -18,7 +18,7 @@ export default function PromoCard({ title, detail, cta, href, chips }: Props) {
       rel="noreferrer"
       className="bento-card flex h-full flex-col gap-4 p-8"
     >
-      <h2 className="text-sm font-medium uppercase tracking-wider text-gray-400">
+      <h2 className="text-sm font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
         {title}
       </h2>
       <p className="text-gray-600 dark:text-gray-300">{detail}</p>
@@ -32,7 +32,7 @@ export default function PromoCard({ title, detail, cta, href, chips }: Props) {
           </li>
         ))}
       </ul>
-      <p className="mt-auto pt-4 text-sm font-medium text-primary-600 dark:text-primary-400">
+      <p className="mt-auto pt-4 text-sm font-medium text-primary-700 dark:text-primary-400">
         {cta}
       </p>
     </a>

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -99,7 +99,7 @@ const TableOfContents = ({ source }: Props) => {
               type="button"
               className={clsx(
                 heading.id === activeId
-                  ? 'font-medium text-primary-600 hover:text-primary-500 dark:text-primary-400'
+                  ? 'font-medium text-primary-700 hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300'
                   : 'font-normal text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200',
                 heading.level === 3 && 'pl-4',
                 'mb-3 text-left text-sm transition-colors hover:underline'

--- a/src/components/atoms/SocialIcon/SocialIcon.tsx
+++ b/src/components/atoms/SocialIcon/SocialIcon.tsx
@@ -29,7 +29,7 @@ const components = {
 // Brand-coloured hover states, keyed by kind. Written as whole class strings so
 // Tailwind's scanner can see them.
 const hoverColors: Record<keyof typeof components, string> = {
-  mail: 'hover:text-primary-600 dark:hover:text-primary-400',
+  mail: 'hover:text-primary-700 dark:hover:text-primary-400',
   github: 'hover:text-gray-500 dark:hover:text-gray-400',
   facebook: 'hover:text-[#4267B2] dark:hover:text-[#4267B2]',
   youtube: 'hover:text-[#FF0000] dark:hover:text-[#FF0000]',

--- a/src/components/organisms/CommandPalette/CommandPalette.tsx
+++ b/src/components/organisms/CommandPalette/CommandPalette.tsx
@@ -103,9 +103,9 @@ export default function CommandPalette({ posts, children }: Props) {
       >
         <Command.Input
           placeholder={t('post-search-placeholder')}
-          className="w-full border-b border-gray-900/10 bg-transparent px-5 py-4 text-base text-gray-900 outline-hidden placeholder:text-gray-400 dark:border-white/10 dark:text-gray-100"
+          className="w-full border-b border-gray-900/10 bg-transparent px-5 py-4 text-base text-gray-900 outline-hidden placeholder:text-gray-500 dark:border-white/10 dark:text-gray-100 dark:placeholder:text-gray-400"
         />
-        <Command.List className="max-h-96 overflow-y-auto overscroll-contain p-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-gray-400">
+        <Command.List className="max-h-96 overflow-y-auto overscroll-contain p-2 [&_[cmdk-group-heading]]:px-3 [&_[cmdk-group-heading]]:py-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wider [&_[cmdk-group-heading]]:text-gray-500 dark:[&_[cmdk-group-heading]]:text-gray-400">
           <Command.Empty className="px-4 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
             {t('search')}: 0
           </Command.Empty>

--- a/src/components/organisms/GroupedPostList/GroupedPostList.tsx
+++ b/src/components/organisms/GroupedPostList/GroupedPostList.tsx
@@ -27,14 +27,16 @@ function SeriesCard({ entry }: { entry: SeriesEntry }) {
     <details className="bento-card series-card group">
       <summary className="flex cursor-pointer list-none items-center justify-between gap-4 p-6 [&::-webkit-details-marker]:hidden sm:p-7">
         <div>
-          <p className="text-xs font-medium uppercase tracking-wider text-primary-600 dark:text-primary-400">
+          <p className="text-xs font-medium uppercase tracking-wider text-primary-700 dark:text-primary-400">
             {t('series')} ·{' '}
             {t('series-post-count', { count: entry.items.length })}
           </p>
           <h3 className="mt-2 text-lg font-bold tracking-tight text-gray-900 dark:text-gray-100 sm:text-xl">
             {entry.name}
           </h3>
-          <p className="mt-1 text-sm text-gray-400">{seriesYearRange(entry)}</p>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {seriesYearRange(entry)}
+          </p>
         </div>
         <svg
           aria-hidden="true"
@@ -43,7 +45,7 @@ function SeriesCard({ entry }: { entry: SeriesEntry }) {
           viewBox="0 0 24 24"
           stroke="currentColor"
           strokeWidth={2}
-          className="h-5 w-5 shrink-0 text-gray-400 transition-transform duration-300 group-open:rotate-180"
+          className="h-5 w-5 shrink-0 text-gray-500 transition-transform duration-300 group-open:rotate-180 dark:text-gray-400"
         >
           <path
             strokeLinecap="round"
@@ -59,15 +61,15 @@ function SeriesCard({ entry }: { entry: SeriesEntry }) {
               href={item.post.path}
               className="group/item flex items-baseline gap-3 py-2"
             >
-              <span className="w-8 shrink-0 text-sm font-medium tabular-nums text-gray-400">
+              <span className="w-8 shrink-0 text-sm font-medium tabular-nums text-gray-500 dark:text-gray-400">
                 {String(item.order).padStart(2, '0')}
               </span>
-              <span className="font-medium text-gray-700 transition-colors group-hover/item:text-primary-600 dark:text-gray-300 dark:group-hover/item:text-primary-400">
+              <span className="font-medium text-gray-700 transition-colors group-hover/item:text-primary-700 dark:text-gray-300 dark:group-hover/item:text-primary-400">
                 {item.shortTitle}
               </span>
               <time
                 dateTime={item.post.date}
-                className="ml-auto hidden shrink-0 text-sm text-gray-400 sm:block"
+                className="ml-auto hidden shrink-0 text-sm text-gray-500 sm:block dark:text-gray-400"
               >
                 {formatDate(item.post.date, locale)}
               </time>
@@ -92,7 +94,7 @@ export default function GroupedPostList({ groups }: Props) {
           key={group.year}
           className="md:grid md:grid-cols-[5.5rem_1fr] md:gap-4"
         >
-          <h2 className="top-20 self-start text-3xl font-bold tabular-nums tracking-tight text-gray-300 transition-colors md:sticky dark:text-gray-700">
+          <h2 className="top-20 self-start text-3xl font-bold tabular-nums tracking-tight text-gray-500 transition-colors md:sticky">
             {group.year}
           </h2>
           <ul className="mt-4 grid grid-cols-1 gap-4 md:mt-0">

--- a/src/components/organisms/PostList/PostCard.tsx
+++ b/src/components/organisms/PostList/PostCard.tsx
@@ -40,7 +40,7 @@ export default function PostCard({ post }: Props) {
         <div className="min-w-0 flex-1">
           <dl>
             <dt className="sr-only">Published on</dt>
-            <dd className="text-sm font-medium text-gray-400 dark:text-gray-500">
+            <dd className="text-sm font-medium text-gray-500 dark:text-gray-400">
               <time dateTime={date}>{formatDate(date, locale)}</time>
             </dd>
           </dl>

--- a/src/components/organisms/ProjectCard/ProjectCard.tsx
+++ b/src/components/organisms/ProjectCard/ProjectCard.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 const iconLinkClassName =
-  'rounded-full p-2 text-gray-400 transition-colors hover:bg-gray-900/5 hover:text-primary-600 dark:hover:bg-white/5 dark:hover:text-primary-400';
+  'rounded-full p-2 text-gray-500 transition-colors hover:bg-gray-900/5 hover:text-primary-700 dark:text-gray-400 dark:hover:bg-white/5 dark:hover:text-primary-400';
 
 function GlobeIcon() {
   return (
@@ -78,7 +78,7 @@ export default function ProjectCard({ project, variant = 'featured' }: Props) {
           <CustomLink
             href={href}
             aria-label={`Link to ${title}`}
-            className="transition-colors hover:text-primary-600 dark:hover:text-primary-400"
+            className="transition-colors hover:text-primary-700 dark:hover:text-primary-400"
           >
             {title}
           </CustomLink>
@@ -126,7 +126,7 @@ export default function ProjectCard({ project, variant = 'featured' }: Props) {
           {post && (
             <CustomLink
               href={post}
-              className="group/link inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 transition-colors hover:text-primary-500 dark:text-primary-400"
+              className="group/link inline-flex items-center gap-1.5 text-sm font-medium text-primary-700 transition-colors hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300"
             >
               {t('learn-more')}
               <span

--- a/src/layouts/ListLayout.tsx
+++ b/src/layouts/ListLayout.tsx
@@ -54,7 +54,7 @@ export default function ListLayout({
             />
             <svg
               aria-hidden="true"
-              className="absolute right-3 top-3 h-5 w-5 text-gray-400 transition-colors dark:text-gray-300"
+              className="absolute right-3 top-3 h-5 w-5 text-gray-500 transition-colors dark:text-gray-300"
               xmlns="http://www.w3.org/2000/svg"
               fill="none"
               viewBox="0 0 24 24"

--- a/src/layouts/PostLayout.tsx
+++ b/src/layouts/PostLayout.tsx
@@ -94,19 +94,19 @@ export default function PostLayout({
             <div className="divide-y divide-gray-200 pt-10 pb-8 transition-colors dark:divide-gray-700 lg:col-span-3">
               <PostBody>
                 {onlyHavePostInAnotherLocale && (
-                  <div className="mb-8 rounded-lg border border-gray-300 bg-gray-100 py-2 px-4 text-center font-medium text-gray-500 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                  <div className="mb-8 rounded-lg border border-gray-300 bg-gray-100 py-2 px-4 text-center font-medium text-gray-600 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300">
                     <Balancer>{t('post-locale-not-available-notice')}</Balancer>
                   </div>
                 )}
                 {aiNoticeKey && (
-                  <div className="mb-8 rounded-lg border border-gray-300 bg-gray-100 py-2 px-4 text-center text-sm text-gray-500 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                  <div className="mb-8 rounded-lg border border-gray-300 bg-gray-100 py-2 px-4 text-center text-sm text-gray-600 transition-colors dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300">
                     <Balancer>
                       {t.rich(aiNoticeKey, {
                         original: (chunks) => (
                           <Link
                             href={pathname}
                             locale={originalLocale}
-                            className="underline transition-colors hover:text-primary-500"
+                            className="underline transition-colors hover:text-primary-700 dark:hover:text-primary-300"
                           >
                             {chunks}
                           </Link>
@@ -141,7 +141,7 @@ export default function PostLayout({
                       </p>
                       <CustomLink
                         href={prev.path}
-                        className="flex gap-1 text-primary-500 transition-colors hover:text-primary-600 dark:hover:text-primary-400"
+                        className="flex gap-1 text-primary-700 transition-colors hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300"
                       >
                         <span>&larr;</span>
                         <span className="grow">
@@ -157,7 +157,7 @@ export default function PostLayout({
                       </p>
                       <CustomLink
                         href={next.path}
-                        className="flex gap-1 text-primary-500 transition-colors hover:text-primary-600 dark:hover:text-primary-400 sm:flex-row-reverse sm:text-right"
+                        className="flex gap-1 text-primary-700 transition-colors hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300 sm:flex-row-reverse sm:text-right"
                       >
                         <span>&rarr;</span>
                         <span className="grow">

--- a/src/layouts/ProjectLayout.tsx
+++ b/src/layouts/ProjectLayout.tsx
@@ -50,7 +50,7 @@ export default function ProjectLayout({ projects }: { projects: Project[] }) {
                 href="https://aburistudio.com"
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-600 transition-colors hover:text-primary-500 dark:text-primary-400"
+                className="inline-flex items-center gap-1.5 text-sm font-medium text-primary-700 transition-colors hover:text-primary-800 dark:text-primary-400 dark:hover:text-primary-300"
               >
                 aburistudio.com
                 <span aria-hidden="true">↗</span>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -165,32 +165,38 @@
  * Prose (posts, about page)
  * ------------------------------------------------------------------------ */
 
-@layer components {
+/* These MUST sit in the `utilities` layer, not `components`.
+ * @tailwindcss/typography registers `.prose` as a utility, and a later cascade
+ * layer wins over an earlier one no matter how specific the selector is — in
+ * `components` every rule below is silently dead. For the same reason each
+ * selector also has to out-specify typography's own `:where()`-wrapped rules
+ * (which land at (0,1,0)), so plain `code` is used rather than `:where(code)`. */
+@layer utilities {
   .prose {
     a {
-      color: var(--color-primary-600);
-      text-decoration-color: --alpha(var(--color-primary-500) / 40%);
+      color: var(--color-primary-700);
+      text-decoration-color: --alpha(var(--color-primary-700) / 40%);
       text-underline-offset: 3px;
       transition:
         color 0.15s,
         text-decoration-color 0.15s;
 
       &:hover {
-        color: var(--color-primary-500);
-        text-decoration-color: var(--color-primary-500);
+        color: var(--color-primary-800);
+        text-decoration-color: var(--color-primary-800);
       }
     }
 
-    :where(code):not(:where(pre code)) {
+    code:not(:where(pre code)) {
       background: var(--color-gray-100);
-      color: var(--color-pink-600);
+      color: var(--color-pink-700);
       padding: 2px 6px;
       border-radius: var(--radius-md);
       font-weight: 500;
     }
 
-    :where(code)::before,
-    :where(code)::after {
+    code::before,
+    code::after {
       content: none;
     }
 
@@ -217,7 +223,7 @@
       }
     }
 
-    :where(code):not(:where(pre code)) {
+    code:not(:where(pre code)) {
       background: var(--color-gray-800);
       color: var(--color-pink-400);
     }
@@ -239,25 +245,33 @@ pre [data-line] {
   padding-inline: 1rem;
 }
 
-/* Shiki emits colors for both themes as CSS vars; switch by class on <html> */
-[data-rehype-pretty-code-figure] span {
+/* Shiki emits colors for both themes as CSS vars; switch by class on <html>.
+ * Scoped to `pre` so it only paints syntax tokens in block code: inline code is
+ * wrapped in a figure span too, and these rules are unlayered, so an unscoped
+ * `span` would repaint every inline snippet with the editor foreground and
+ * override the `.prose code` color above. */
+[data-rehype-pretty-code-figure] pre span {
   color: var(--shiki-light);
 }
 
-.dark [data-rehype-pretty-code-figure] span {
+.dark [data-rehype-pretty-code-figure] pre span {
   color: var(--shiki-dark);
 }
 
+/* Block code only. rehype-pretty-code also wraps *inline* code in a
+ * [data-rehype-pretty-code-figure] span, and these rules are unlayered, so a
+ * bare `code` here would beat the layered `.prose code` styling above and
+ * repaint every inline snippet with the editor-theme background. */
 [data-rehype-pretty-code-figure] {
   pre,
-  code {
+  pre code {
     background: var(--shiki-light-bg);
   }
 }
 
 .dark [data-rehype-pretty-code-figure] {
   pre,
-  code {
+  pre code {
     background: var(--shiki-dark-bg);
   }
 }


### PR DESCRIPTION
## What

Two commits:

1. **Contrast fixes** across section labels, muted metadata, and brand links.
2. **Reviving `src/styles/index.css`'s `.prose` block**, which turned out to be entirely dead code.

## 1 — Contrast

Several section titles and muted labels rendered well below WCAG 2.1 AA, most visibly the two originally reported:

| Element | Before | Needs | After |
| --- | --- | --- | --- |
| `Get in Touch` / `Featured Projects` / `Latest Posts` / `Build in Public` | **2.58:1** | 4.5:1 | 4.73:1 |
| `2026` year rail on `/posts` | **1.48:1** light, **1.91:1** dark | 3:1 | 4.73 / 4.18:1 |

Changes:

- **Muted grays** — `text-gray-400` → `text-gray-500 dark:text-gray-400`. Post-card dates had the pair *inverted* (`text-gray-400 dark:text-gray-500`), so they failed in both themes.
- **Year rail** — `text-gray-500` in both themes; still clearly subordinate to post titles, just legible.
- **Brand teal on light backgrounds** — `text-primary-600` (3.66) and `text-primary-500` (2.42) → `text-primary-700` (5.39). Hover now goes *darker* (primary-800, 7.53) instead of lightening into a worse ratio; dark mode keeps primary-400 and hovers to primary-300. Both themes now gain contrast on hover rather than losing it.
- **Email CTA** — white on `bg-primary-600` was 3.66:1 → `bg-primary-700` (5.39), hover `bg-primary-800` (7.53).
- **AI / locale notices** — gray-500 on the gray-100 panel was 4.34:1, just under the line → gray-600 (7.15).
- Also swept: command palette placeholder + group headings, project-card icon links, and the code-block copy button (dark border at 1.35:1).

Most were light-mode-only failures caused by a muted class with no `dark:` counterpart.

## 2 — The dead `.prose` block

Every color and content rule under `.prose` was silently doing nothing. The block sat in the **`components`** layer, but `@tailwindcss/typography` registers `.prose` as a **utility** — and a later cascade layer beats an earlier one regardless of specificity. The compiled CSS confirms the order: `properties, theme, base, components, utilities`.

The visible fallout was broader than the link color:

- Links and inline code rendered in typography's near-black default, never the intended teal/pink.
- Inline code showed **literal backticks** — `content: none` lost to typography's `code::before { content: "`" }`.
- Inline code had no pill background or weight of its own.
- Blockquotes stayed italic and kept smart quotes.

Fixes:

- Moved the block to `@layer utilities`, where specificity decides. Each selector now out-specifies typography's `:where()`-wrapped rules (which sit at `(0,1,0)`), so plain `code` replaces `:where(code)`.
- Two **unlayered** rehype-pretty-code rules also needed scoping to `pre`. Inline code is wrapped in a `[data-rehype-pretty-code-figure]` span too, so the unscoped `code` background and `span` color rules were repainting every inline snippet with the editor theme — and unlayered CSS beats *any* layer, so they clobbered `.prose code` regardless of the move above. Block code is untouched and keeps its github-light / one-dark-pro syntax colors.

Because these colors now actually render, they had to clear AA on the way in:

- Links: primary-600 (3.66) → primary-700 (5.39); hover primary-500 (2.42) → primary-800 (7.53). Dark keeps primary-400 (10.61) → primary-300 (13.45).
- Inline code: pink-600 on gray-100 was 4.17 → pink-700 (5.40). Dark keeps pink-400 on gray-800 (5.48).

## How I audited

A scripted Playwright pass walks every element with its own text node, composites the real effective background up the ancestor chain, and computes the WCAG ratio — applying the 3:1 large-text threshold where the computed font size/weight earns it, and skipping `aria-hidden` decorative nodes. Two details mattered:

- Computed colors come back as `oklch()`/`lab()` under Tailwind v4, so colors are normalized through a canvas rather than regex-parsed.
- A second pass rewrites every `:hover` rule to apply at rest, so hover states are audited too — that's what caught the links whose hover *lowered* contrast.

I validated the script against the pre-fix build first (**26** distinct failures, including both reported ones) so a post-fix zero couldn't just mean a broken script.

Coverage: **9 pages × 2 themes × resting/hover** — now including posts with inline code, code blocks, images and blockquotes.

**Result: all site-authored CSS reports zero failures.**

## Known remaining findings (not changed here)

1. **Shiki syntax-token colors** in block code, from the upstream themes — `children` at 3.49:1 and `import` at 4.06:1 in github-light; `Provider` 4.38:1, `import` 3.94:1, comments 3.73:1 in one-dark-pro. Pre-existing and unrelated to these changes; fixing means swapping or overriding the editor themes, which is a visible aesthetic call. Happy to follow up with the `*-high-contrast` variants if you want it.
2. **Social icon brand hover colors** (RSS orange ~1.9:1, Twitter blue ~2.6:1 on white) — deliberate brand colors, resting state passes, and each icon carries an `sr-only` label.

## Verification

`pnpm lint` · `pnpm test` (31 passed) · `pnpm build` · `pnpm test:e2e` (20 passed) — all green.